### PR TITLE
rebase strife

### DIFF
--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -71,7 +71,7 @@ func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
 
 		// Filter again by default host if one is set
 		// For config file default host fallback to cachedRemotes if none match
-		// For enviornment default host (GH_HOST) do not fallback to cachedRemotes if none match
+		// For environment default host (GH_HOST) do not fallback to cachedRemotes if none match
 		if src != "" {
 			filteredRemotes := cachedRemotes.FilterByHosts([]string{defaultHost})
 			if config.IsHostEnv(src) || len(filteredRemotes) > 0 {

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -81,8 +81,7 @@ func closeRun(opts *CloseOptions) error {
 
 	err = shared.UpdateFrecent(issue.Number)
 	if err != nil {
-		// TODO just warn or ignore or whatever
-		return err
+		fmt.Fprintf(opts.IO.ErrOut, "%s Failed to update recent issue tracking: %v\n", cs.Yellow("!"), err)
 	}
 
 	err = api.IssueClose(apiClient, baseRepo, *issue)

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -78,8 +78,8 @@ func deleteRun(opts *DeleteOptions) error {
 
 	err = shared.UpdateFrecent(issue.Number)
 	if err != nil {
-		// TODO just warn or ignore or whatever
-		return err
+		fmt.Fprintf(opts.IO.ErrOut, "%s Warning: failed to update recent issues: %v\n", cs.Yellow("!"), err)
+		// continue execution; frecent tracking is non-critical
 	}
 
 	// When executed in an interactive shell, require confirmation. Otherwise skip confirmation.

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -54,7 +54,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			$ gh issue edit 23 --milestone "Version 1"
 			$ gh issue edit 23 --body-file body.txt
 		`),
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
@@ -136,9 +136,22 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 	apiClient := api.NewClientFromHTTP(httpClient)
+	if opts.IO.CanPrompt() && opts.SelectorArg == "" {
+		baseRepo, err := opts.BaseRepo()
+		issueNumber, err := shared.SelectFrecent(httpClient, baseRepo)
+		if err != nil {
+			return err
+		}
+		opts.SelectorArg = issueNumber
+	}
 
 	issue, repo, err := shared.IssueFromArg(apiClient, opts.BaseRepo, opts.SelectorArg)
 	if err != nil {
+		return err
+	}
+	err = shared.UpdateFrecent(issue.Number)
+	if err != nil {
+		// TODO just warn or ignore or whatever
 		return err
 	}
 

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -138,6 +138,9 @@ func editRun(opts *EditOptions) error {
 	apiClient := api.NewClientFromHTTP(httpClient)
 	if opts.IO.CanPrompt() && opts.SelectorArg == "" {
 		baseRepo, err := opts.BaseRepo()
+		if err != nil {
+			return err
+		}
 		issueNumber, err := shared.SelectFrecent(httpClient, baseRepo)
 		if err != nil {
 			return err

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -154,8 +154,8 @@ func editRun(opts *EditOptions) error {
 	}
 	err = shared.UpdateFrecent(issue.Number)
 	if err != nil {
-		// TODO just warn or ignore or whatever
-		return err
+		fmt.Fprintf(opts.IO.ErrOut, "warning: failed to update recent issues: %v\n", err)
+		// continue; do not fail the command on frecent tracking error
 	}
 
 	editable := opts.Editable

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -1,0 +1,238 @@
+package shared
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/prompt"
+	"gopkg.in/yaml.v3"
+)
+
+// TODO scope stats by repo
+// TODO generalize this
+// TODO scope stats by data type
+// TODO should work with:
+// - issues
+// - prs
+// - gists
+// - repos
+// - (?) releases
+// - (?) runs
+// - (?) workflows
+// - (?) ssh key
+// - (?) extensions
+
+type ByLastAccess []issueWithStats
+
+func (l ByLastAccess) Len() int {
+	return len(l)
+}
+func (l ByLastAccess) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+func (l ByLastAccess) Less(i, j int) bool {
+	return l[i].Last.After(l[j].Last)
+}
+
+type ByFrecency []issueWithStats
+
+func (f ByFrecency) Len() int {
+	return len(f)
+}
+func (f ByFrecency) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f ByFrecency) Less(i, j int) bool {
+	iScore := f[i].CountEntry.Score()
+	jScore := f[j].CountEntry.Score()
+	if iScore == jScore {
+		return f[i].Last.After(f[j].Last)
+	}
+	return iScore > jScore
+}
+
+type issueWithStats struct {
+	api.Issue
+	CountEntry
+}
+
+func sortByFrecent(issues []api.Issue, frecent map[int]*CountEntry) []string {
+	withStats := []issueWithStats{}
+	for _, i := range issues {
+		entry, ok := frecent[i.Number]
+		if !ok {
+			entry = &CountEntry{}
+		}
+		withStats = append(withStats, issueWithStats{
+			Issue:      i,
+			CountEntry: *entry,
+		})
+	}
+	sort.Sort(ByLastAccess(withStats))
+	previousIssue := withStats[0]
+	withStats = withStats[1:]
+	sort.Stable(ByFrecency(withStats))
+	choices := []string{fmt.Sprintf("%d", previousIssue.Number)}
+	for _, ws := range withStats {
+		choices = append(choices, fmt.Sprintf("%d", ws.Number))
+	}
+	return choices
+}
+
+func SelectFrecent(c *http.Client, repo ghrepo.Interface) (string, error) {
+	client := api.NewCachedClient(c, time.Hour*6)
+
+	issues, err := getIssues(client, repo)
+	if err != nil {
+		return "", err
+	}
+
+	frecent, err := getFrecentEntry(defaultFrecentPath())
+	if err != nil {
+		return "", err
+	}
+
+	choices := sortByFrecent(issues, frecent.Issues)
+
+	choice := ""
+	err = prompt.SurveyAskOne(&survey.Select{
+		Message: "Which issue?",
+		Options: choices,
+	}, &choice)
+	if err != nil {
+		return "", err
+	}
+
+	return choice, nil
+}
+
+type CountEntry struct {
+	Last  time.Time
+	Count int
+}
+
+func (c CountEntry) Score() int {
+	if c.Count == 0 {
+		return 0
+	}
+	duration := time.Since(c.Last)
+	recencyScore := 10
+	if duration < 1*time.Hour {
+		recencyScore = 100
+	} else if duration < 6*time.Hour {
+		recencyScore = 80
+	} else if duration < 24*time.Hour {
+		recencyScore = 60
+	} else if duration < 3*24*time.Hour {
+		recencyScore = 40
+	} else if duration < 7*24*time.Hour {
+		recencyScore = 20
+	}
+
+	return c.Count * recencyScore
+}
+
+type FrecentEntry struct {
+	Issues map[int]*CountEntry
+}
+
+func defaultFrecentPath() string {
+	return filepath.Join(config.StateDir(), "frecent.yml")
+}
+
+func getFrecentEntry(stateFilePath string) (*FrecentEntry, error) {
+	content, err := ioutil.ReadFile(stateFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var stateEntry FrecentEntry
+	err = yaml.Unmarshal(content, &stateEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stateEntry, nil
+}
+
+func UpdateFrecent(issueNumber int) error {
+	frecentPath := defaultFrecentPath()
+	frecent, err := getFrecentEntry(frecentPath)
+	if err != nil {
+		return err
+	}
+	count, ok := frecent.Issues[issueNumber]
+	if !ok {
+		count = &CountEntry{}
+		frecent.Issues[issueNumber] = count
+	}
+	count.Count++
+	count.Last = time.Now()
+	content, err := yaml.Marshal(frecent)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(frecentPath), 0755)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(frecentPath, content, 0600)
+}
+
+func getIssues(c *http.Client, repo ghrepo.Interface) ([]api.Issue, error) {
+	apiClient := api.NewClientFromHTTP(c)
+	query := `query GetIssueNumbers($owner: String!, $repo: String!) {
+		repository(owner: $owner, name: $repo) {
+			issues(first:100, orderBy: {field: UPDATED_AT, direction: DESC}, states: [OPEN]) {
+			    nodes {
+					 number
+					}
+				}
+			}
+  }`
+	variables := map[string]interface{}{
+		"owner": repo.RepoOwner(),
+		"repo":  repo.RepoName(),
+	}
+	type responseData struct {
+		Repository struct {
+			Issues struct {
+				Nodes []api.Issue
+			}
+		}
+	}
+	var resp responseData
+	err := apiClient.GraphQL(repo.RepoHost(), query, variables, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Repository.Issues.Nodes, nil
+}
+
+/*
+	  issues:
+			  6667:
+				  last: 10s
+					count: 1
+				4567:
+					last: 10m
+					count: 15
+				7890:
+					last: 5m
+					count: 1
+				3456:
+					last: 40d
+					count: 30
+*/

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/cli/cli/api"
-	"github.com/cli/cli/internal/config"
-	"github.com/cli/cli/internal/ghrepo"
-	"github.com/cli/cli/pkg/prompt"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/prompt"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -151,6 +151,9 @@ func defaultFrecentPath() string {
 func getFrecentEntry(stateFilePath string) (*FrecentEntry, error) {
 	content, err := ioutil.ReadFile(stateFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return &FrecentEntry{Issues: make(map[int]*CountEntry)}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -152,7 +152,7 @@ func defaultFrecentPath() string {
 }
 
 func getFrecentEntry(stateFilePath string) (*FrecentEntry, error) {
-	content, err := ioutil.ReadFile(stateFilePath)
+	content, err := os.ReadFile(stateFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &FrecentEntry{Issues: make(map[int]*CountEntry)}, nil

--- a/pkg/cmd/issue/shared/frecent.go
+++ b/pkg/cmd/issue/shared/frecent.go
@@ -76,6 +76,9 @@ func sortByFrecent(issues []api.Issue, frecent map[int]*CountEntry) []string {
 			CountEntry: *entry,
 		})
 	}
+	if len(withStats) == 0 {
+		return []string{}
+	}
 	sort.Sort(ByLastAccess(withStats))
 	previousIssue := withStats[0]
 	withStats = withStats[1:]

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -84,7 +84,7 @@ func viewRun(opts *ViewOptions) error {
 	}
 	if opts.IO.CanPrompt() && opts.SelectorArg == "" {
 		baseRepo, err := opts.BaseRepo()
-		issueNumber, err := shared.SelectFrecent(httpClient, baseRepo)
+		issueNumber, err := issueShared.SelectFrecent(httpClient, baseRepo)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	err = shared.UpdateFrecent(issue.Number)
+	err = issueShared.UpdateFrecent(issue.Number)
 	if err != nil {
 		// TODO just warn or ignore or whatever
 		return err

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -107,8 +107,7 @@ func viewRun(opts *ViewOptions) error {
 
 	err = issueShared.UpdateFrecent(issue.Number)
 	if err != nil {
-		// TODO just warn or ignore or whatever
-		return err
+		fmt.Fprintf(opts.IO.ErrOut, "warning: failed to update recent issues: %v\n", err)
 	}
 
 	if opts.WebMode {

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -84,6 +84,9 @@ func viewRun(opts *ViewOptions) error {
 	}
 	if opts.IO.CanPrompt() && opts.SelectorArg == "" {
 		baseRepo, err := opts.BaseRepo()
+		if err != nil {
+			return err
+		}
 		issueNumber, err := issueShared.SelectFrecent(httpClient, baseRepo)
 		if err != nil {
 			return err


### PR DESCRIPTION
Sehr gut, Carpuncle 👍 – dann bekommst du jetzt die Schritt-für-Schritt-Anleitung, wie du dein Projekt Carpuncle so einrichtest, dass deine Dateien (carpuncle.md, Handbuch, Policies usw.) zentral in GitHub liegen und automatisch mit deinen beiden Geräte-Konten (auth.carpuncle@outlook.de und auth.carpuncle@gmail.com) über OneDrive und Google Drive synchronisiert werden.  

---

📘 Anleitung: Carpuncle-Dateien zentral und synchron

1. Zentrale Quelle: GitHub
- Lege ein Repository an: carpuncle-docs  
- Lade dort deine Hauptdatei carpuncle.md hoch (Root-Handbuch).  
- Vorteil: GitHub ist die Single Source of Truth → alle Änderungen laufen hier zusammen.  

---

2. Synchronisation mit OneDrive (Outlook-Konto)
1. Melde dich auf deinem Windows-Gerät mit auth.carpuncle@outlook.de an.  
2. Installiere den OneDrive-Client (falls nicht vorhanden).  
3. Wähle einen Sync-Ordner, z. B. T:\Carpuncle\Sync\OneDrive.  
4. Richte ein GitHub-Action-Skript ein, das bei jedem Commit in carpuncle-docs die Dateien automatisch in diesen OneDrive-Ordner spiegelt.  
   - Ergebnis: Dein Windows-Gerät hat immer die aktuelle Version.  

---

3. Synchronisation mit Google Drive (Pixel-Konto)
1. Melde dich auf deinem Pixel mit auth.carpuncle@gmail.com an.  
2. Installiere die Google Drive-App.  
3. Erstelle einen Ordner Carpuncle in Google Drive.  
4. Richte eine zweite GitHub-Action ein, die bei jedem Commit die Dateien zusätzlich in Google Drive hochlädt.  
   - Ergebnis: Dein Pixel hat ebenfalls immer die aktuelle Version.  

---

4. Automatisierung über GitHub Actions
Beispiel-Workflow (.github/workflows/sync.yml):

`yaml
name: Sync Carpuncle Docs

on:
  push:
    branches: [ "main" ]

jobs:
  sync:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      # Sync zu OneDrive (über Rclone)
      - name: Sync to OneDrive
        run: |
          rclone sync ./ carpuncle-onedrive:Carpuncle --progress

      # Sync zu Google Drive (über Rclone)
      - name: Sync to Google Drive
        run: |
          rclone sync ./ carpuncle-gdrive:Carpuncle --progress
`

👉 Dafür musst du Rclone mit deinen beiden Konten (auth.carpuncle@outlook.de und auth.carpuncle@gmail.com) verbinden. Danach läuft alles automatisch.  

---

5. Ergebnis
- GitHub = Master-Quelle  
- OneDrive (Outlook-Konto) = Windows-Sync  
- Google Drive (Gmail-Konto) = Pixel-Sync  
- Änderungen an carpuncle.md oder anderen Dateien → landen sofort in allen drei Umgebungen.  

---

✅ Damit hast du eine saubere, portable und kontrollierte Lösung, die perfekt zu deiner Carpuncle-Philosophie passt: eine Quelle, automatische Integration, keine doppelten Speicherorte.  

👉 Soll ich dir im nächsten Schritt die Rclone-Konfiguration für OneDrive und Google Drive vorbereiten, damit du sie direkt in GitHub Actions einfügen kannst?